### PR TITLE
Don't nuke bindings

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ function stripGlimmerUtils(babel) {
               if (path.parentPath.isCallExpression()) {
                 path.parentPath.replaceWith(path.parentPath.node.arguments[0]);
               }
-              b.path.remove();
             });
+
+            b.path.remove();
           }
         });
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "repository": {},
   "author": "Chad Hietala <chadhietala@gmail.com>",
   "license": "MIT",
+  "keywords": [
+    "babel-plugin"
+  ],
   "devDependencies": {
     "babel-core": "^6.24.0",
     "qunitjs": "^2.3.0"

--- a/test.js
+++ b/test.js
@@ -71,3 +71,28 @@ class Foo {
   }
 }`)
 });
+
+QUnit.test(`handles multiple bindings`, (assert) => {
+  let transformed = transform(`
+    import { expect, A } from '@glimmer/util';
+    class Foo {
+      foo(arg) {
+        return expect(A(arg), 'wat wat');
+      }
+      bar(arg) {
+        return expect(A(arg), 'wat wat');
+      }
+    }
+  `);
+
+  assert.equal(transformed, `
+import { A } from '@glimmer/util';
+class Foo {
+  foo(arg) {
+    return A(arg);
+  }
+  bar(arg) {
+    return A(arg);
+  }
+}`)
+});


### PR DESCRIPTION
This is prematurely nuking the import binding which was problematic when there were multiple calls per file.